### PR TITLE
Use the most recent version of SQL Server as default

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ This default options will be merged with task-defined
 ```js
 {
     exePath: 'Migrate.exe',
-    provider: 'sqlserver2012',
+    provider: 'sqlserver2014',
     task: 'migrate'
 }
 ```

--- a/tasks/fluentmigrator.js
+++ b/tasks/fluentmigrator.js
@@ -7,7 +7,7 @@ module.exports = function(grunt) {
     grunt.registerMultiTask('fluentmigrator', 'Fluent migrator cli wrapper', function() {
         var options = _.extend(this.options({
                 exePath: 'Migrate.exe',
-                provider: 'sqlserver2012',
+                provider: 'sqlserver2014',
                 task: 'migrate'
             }), this.data),
             done = this.async(),


### PR DESCRIPTION
Not a big deal, but since fluent migrator supports it, I thought would be better the newer version be the default and those with older versions change it.