### PR TITLE
Accept more than one fluent migrator grunt configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,11 +7,20 @@ grunt.initConfig({
         options: {
             exePath: 'tools/migrator/Migrate.exe'
         },
-        file: {
-            assembly : 'src/SomeProject.Migrations/bin/Debug/SomeProject.Migrations.dll',
-            output: true,
-            outputFileName: 'migrated.sql',
-            conn: "Server=.;initial catalog=SiteDb;Integrated Security=true;"
+        dev: {
+            file: {
+                assembly : 'src/SomeProject.Migrations/bin/Debug/SomeProject.Migrations.dll',
+                output: true,
+                outputFileName: 'migrated.sql',
+                conn: "Server=.;initial catalog=SiteDb;Integrated Security=true;"
+            }
+        }
+        staging: {
+            file: {
+                assembly : 'src/SomeProject.Migrations/bin/Staging/SomeProject.Migrations.dll',
+                output: false,
+                conn: "Server=.;initial catalog=SiteDb;Integrated Security=true;"
+            }
         }
     }
 })

--- a/tasks/fluentmigrator.js
+++ b/tasks/fluentmigrator.js
@@ -9,7 +9,7 @@ module.exports = function(grunt) {
                 exePath: 'Migrate.exe',
                 provider: 'sqlserver2012',
                 task: 'migrate'
-            }), this.data),
+            }), this.data.file || this.data),
             done = this.async(),
             log = function(message) {
                 console.log(message.toString('utf8'));


### PR DESCRIPTION
Allows multiple grunt configurations, like:
```
grunt.initConfig({
    fluentmigrator: {
        options: {
            exePath: 'tools/migrator/Migrate.exe'
        },
        dev: {
            file: {
                assembly : 'src/SomeProject.Migrations/bin/Debug/SomeProject.Migrations.dll',
                output: true,
                outputFileName: 'migrated.sql',
                conn: "Server=.;initial catalog=SiteDb;Integrated Security=true;"
            }
        }
        staging: {
            file: {
                assembly : 'src/SomeProject.Migrations/bin/Staging/SomeProject.Migrations.dll',
                output: false,
                conn: "Server=.;initial catalog=SiteDb;Integrated Security=true;"
            }
        }
    }
})
```

The previous way (without the environment) still works.